### PR TITLE
test: add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+coverage
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,6 @@ doc
 example
 test
 scripts
+
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "mocha": "^5.1.1",
-    "nanobench": "^2.1.1"
+    "nanobench": "^2.1.1",
+    "nyc": "^15.0.0"
   },
   "homepage": "https://github.com/jhermsmeier/node-envelope",
   "repository": {
@@ -32,7 +33,7 @@
     "url": "https://github.com/jhermsmeier/node-envelope/issues"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "nyc mocha",
     "benchmark": "nanobench benchmark/*.js"
   }
 }


### PR DESCRIPTION
If you don't want the package-lock, I can rebase with a `.gitignore` (or if you prefer `.ncurc`), but I find a lock file helpful, including for the ability to perform `npm audit`.